### PR TITLE
Corretto il testo del cinque maggio

### DIFF
--- a/src/poesie.json
+++ b/src/poesie.json
@@ -54,20 +54,17 @@
       "autore": "Alessandro Manzoni",
       "strofe": [
         "Ei fu. Siccome immobile,",
-        "dato il fatal sospiro,",
-        "stette la salma immemore,",
+        "dato il mortal sospiro,",
+        "stette la spoglia immemore,",
         "orba di tanto spiro,",
-        "Tale al tonante annunzio",
-        "Muta la terra sta,",
-        "Trema la terra e sta.",
-        "Così percossa, attonita",
-        "La terra al nunzio sta.",
-        "Che innanzi a lui già tacquesi,",
-        "che lo nomò fatale",
-        "Né sa quando una simile",
-        "Orma di piè mortale",
-        "La sua cruenta polvere",
-        "A calpestar verrà."
+        "così percossa, attonita",
+        "la terra al nunzio sta",
+        "muta pensando all'ultima",
+        "Ora dell'uom fatale",
+        "nè sa quando una simile",
+        "orma di piè mortale",
+        "la sua cruenta polvere",
+        "a calpestar verrà.".
       ]
     },
     {


### PR DESCRIPTION
Il testo della poesia il 5 maggio era errato ed ora è stato modificando il testo per includere le prime due strofe in modo corretto.